### PR TITLE
Add Clients page with animated tiles and move content

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -39,6 +39,7 @@ const router = createBrowserRouter([
       { path: "/", element: <Index /> },
       { path: "/about", element: <About /> },
       { path: "/services", element: <Services /> },
+      { path: "/clients", element: <Clients /> },
       { path: "/insights", element: <Insights /> },
       { path: "/careers", element: <Careers /> },
       { path: "/contact", element: <Contact /> },

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 const About = lazy(() => import("./pages/About"));
 const Services = lazy(() => import("./pages/Services"));
+const Clients = lazy(() => import("./pages/Clients"));
 const Insights = lazy(() => import("./pages/Insights"));
 const Careers = lazy(() => import("./pages/Careers"));
 const Contact = lazy(() => import("./pages/Contact"));

--- a/client/components/site/ClientsInfographic.tsx
+++ b/client/components/site/ClientsInfographic.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from "react";
+
+export default function ClientsInfographic() {
+  const [data, setData] = useState<any | null>(null);
+
+  useEffect(() => {
+    let canceled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/clients");
+        const arr = await res.json();
+        if (canceled) return;
+        if (Array.isArray(arr) && arr.length) {
+          const first = arr.find((x: any) => x.enabled !== false) || arr[0];
+          setData(first);
+        }
+      } catch (e) {
+        console.error("Failed to load clients", e);
+      }
+    })();
+    return () => {
+      canceled = true;
+    };
+  }, []);
+
+  if (!data) return null;
+
+  const items = Array.isArray(data.details) ? data.details : [];
+
+  return (
+    <section className="mt-12">
+      <div className="max-w-4xl mx-auto text-center">
+        <h2 className="text-3xl font-extrabold text-foreground">{data.heading}</h2>
+        {data.subheading && <p className="mt-3 text-foreground/85">{data.subheading}</p>}
+      </div>
+
+      <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-5xl mx-auto items-start">
+        {items.map((it: any, idx: number) => (
+          <div key={idx} className="flex flex-col items-center text-center p-6">
+            <div className="flex items-center justify-center h-28 w-28 rounded-full bg-gradient-to-br from-primary/20 to-primary/10 border border-primary/20 glass-card">
+              <div className="text-2xl font-extrabold text-foreground">{it.count}</div>
+            </div>
+            <div className="mt-4 font-semibold text-foreground">{it.industry}</div>
+            <div className="mt-1 text-sm text-foreground/80">{it.region}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/client/components/site/ClientsInfographic.tsx
+++ b/client/components/site/ClientsInfographic.tsx
@@ -32,8 +32,12 @@ export default function ClientsInfographic() {
   return (
     <section className="mt-12">
       <div className="max-w-4xl mx-auto text-center">
-        <h2 className="text-3xl font-extrabold text-foreground">{data.heading}</h2>
-        {data.subheading && <p className="mt-3 text-foreground/85">{data.subheading}</p>}
+        <h2 className="text-3xl font-extrabold text-foreground">
+          {data.heading}
+        </h2>
+        {data.subheading && (
+          <p className="mt-3 text-foreground/85">{data.subheading}</p>
+        )}
       </div>
 
       <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-5xl mx-auto items-start">
@@ -41,16 +45,23 @@ export default function ClientsInfographic() {
           const duration = 6 + (idx % 3) * 1.5; // vary duration per tile
           const delay = idx * 0.25; // stagger
           return (
-            <div key={idx} className="flex flex-col items-center text-center p-6 group">
+            <div
+              key={idx}
+              className="flex flex-col items-center text-center p-6 group"
+            >
               <div
                 className="flex items-center justify-center h-28 w-28 rounded-full bg-gradient-to-br from-primary/20 to-primary/10 border border-primary/20 glass-card will-change-transform"
                 style={{
                   animation: `floaty ${duration}s ease-in-out ${delay}s infinite`,
                 }}
               >
-                <div className="text-2xl font-extrabold text-foreground">{it.count}</div>
+                <div className="text-2xl font-extrabold text-foreground">
+                  {it.count}
+                </div>
               </div>
-              <div className="mt-4 font-semibold text-foreground">{it.industry}</div>
+              <div className="mt-4 font-semibold text-foreground">
+                {it.industry}
+              </div>
               <div className="mt-1 text-sm text-foreground/80">{it.region}</div>
             </div>
           );

--- a/client/components/site/ClientsInfographic.tsx
+++ b/client/components/site/ClientsInfographic.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
 
+import React, { useEffect, useState } from "react";
+
 export default function ClientsInfographic() {
   const [data, setData] = useState<any | null>(null);
 

--- a/client/components/site/ClientsInfographic.tsx
+++ b/client/components/site/ClientsInfographic.tsx
@@ -37,15 +37,24 @@ export default function ClientsInfographic() {
       </div>
 
       <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-5xl mx-auto items-start">
-        {items.map((it: any, idx: number) => (
-          <div key={idx} className="flex flex-col items-center text-center p-6">
-            <div className="flex items-center justify-center h-28 w-28 rounded-full bg-gradient-to-br from-primary/20 to-primary/10 border border-primary/20 glass-card">
-              <div className="text-2xl font-extrabold text-foreground">{it.count}</div>
+        {items.map((it: any, idx: number) => {
+          const duration = 6 + (idx % 3) * 1.5; // vary duration per tile
+          const delay = idx * 0.25; // stagger
+          return (
+            <div key={idx} className="flex flex-col items-center text-center p-6 group">
+              <div
+                className="flex items-center justify-center h-28 w-28 rounded-full bg-gradient-to-br from-primary/20 to-primary/10 border border-primary/20 glass-card will-change-transform"
+                style={{
+                  animation: `floaty ${duration}s ease-in-out ${delay}s infinite`,
+                }}
+              >
+                <div className="text-2xl font-extrabold text-foreground">{it.count}</div>
+              </div>
+              <div className="mt-4 font-semibold text-foreground">{it.industry}</div>
+              <div className="mt-1 text-sm text-foreground/80">{it.region}</div>
             </div>
-            <div className="mt-4 font-semibold text-foreground">{it.industry}</div>
-            <div className="mt-1 text-sm text-foreground/80">{it.region}</div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -72,6 +72,9 @@ interface AboutData {
   valuesHeading?: string | null;
   valuesSubheading?: string | null;
   valuesCards?: AwardItem[] | null;
+  serveHeading?: string | null;
+  serveSubheading?: string | null;
+  serveSteps?: any[] | null;
 }
 
 interface AnimatedCounterProps {
@@ -554,11 +557,11 @@ export default function About() {
       >
         <div className="text-center mb-12">
           <h2 className="text-3xl sm:text-4xl font-extrabold text-foreground">
-            How We Serve
+            {about?.serveHeading || "How We Serve"}
           </h2>
           <p className="mt-4 text-foreground/85 max-w-2xl mx-auto">
-            Our proven methodology that ensures successful project delivery from
-            concept to completion.
+            {about?.serveSubheading ||
+              "Our proven methodology that ensures successful project delivery from concept to completion."}
           </p>
         </div>
 
@@ -575,42 +578,42 @@ export default function About() {
             }}
             className="space-y-12"
           >
-            {[
-              {
-                phase: "01",
-                title: "Discover",
-                description:
-                  "Align on goals, constraints, and success metrics. We dive deep into understanding your vision and requirements.",
-                icon: Target,
-                position: "left",
-              },
-              {
-                phase: "02",
-                title: "Design",
-                description:
-                  "Prototype, test, refine with users and stakeholders. Creating user-centered designs that solve real problems.",
-                icon: Globe,
-                position: "right",
-              },
-              {
-                phase: "03",
-                title: "Build",
-                description:
-                  "Implement iteratively with quality gates and CI. Building robust, scalable solutions with modern technologies.",
-                icon: TrendingUp,
-                position: "left",
-              },
-              {
-                phase: "04",
-                title: "Evolve",
-                description:
-                  "Measure outcomes, learn, and iterate. Continuous improvement based on data and user feedback.",
-                icon: Zap,
-                position: "right",
-              },
-            ].map((step, idx) => {
-              const Icon = step.icon as any;
-              const isLeft = step.position === "left";
+            {(
+              (Array.isArray((about as any)?.serveSteps) && (about as any).serveSteps.length
+                ? (about as any).serveSteps
+                : [
+                    {
+                      phase: "01",
+                      title: "Discover",
+                      description:
+                        "Align on goals, constraints, and success metrics. We dive deep into understanding your vision and requirements.",
+                      icon: "target",
+                    },
+                    {
+                      phase: "02",
+                      title: "Design",
+                      description:
+                        "Prototype, test, refine with users and stakeholders. Creating user-centered designs that solve real problems.",
+                      icon: "globe",
+                    },
+                    {
+                      phase: "03",
+                      title: "Build",
+                      description:
+                        "Implement iteratively with quality gates and CI. Building robust, scalable solutions with modern technologies.",
+                      icon: "trending-up",
+                    },
+                    {
+                      phase: "04",
+                      title: "Evolve",
+                      description:
+                        "Measure outcomes, learn, and iterate. Continuous improvement based on data and user feedback.",
+                      icon: "zap",
+                    },
+                  ]) as any[]
+            ).map((step: any, idx: number) => {
+              const Icon = (getIconByName(step?.icon) as any) || Target;
+              const isLeft = idx % 2 === 0;
               return (
                 <motion.div
                   key={idx}
@@ -641,7 +644,7 @@ export default function About() {
                         </div>
                         <div>
                           <div className="text-xs font-bold text-primary/100 mb-1">
-                            PHASE {step.phase}
+                            PHASE {step?.phase || String(idx + 1).padStart(2, "0")}
                           </div>
                           <h3 className="text-xl font-bold text-foreground mb-2">
                             {step.title}

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -579,7 +579,8 @@ export default function About() {
             className="space-y-12"
           >
             {(
-              (Array.isArray((about as any)?.serveSteps) && (about as any).serveSteps.length
+              (Array.isArray((about as any)?.serveSteps) &&
+              (about as any).serveSteps.length
                 ? (about as any).serveSteps
                 : [
                     {
@@ -644,7 +645,8 @@ export default function About() {
                         </div>
                         <div>
                           <div className="text-xs font-bold text-primary/100 mb-1">
-                            PHASE {step?.phase || String(idx + 1).padStart(2, "0")}
+                            PHASE{" "}
+                            {step?.phase || String(idx + 1).padStart(2, "0")}
                           </div>
                           <h3 className="text-xl font-bold text-foreground mb-2">
                             {step.title}

--- a/client/pages/Clients.tsx
+++ b/client/pages/Clients.tsx
@@ -1,0 +1,12 @@
+import Section from "@/components/site/Section";
+import ClientsInfographic from "@/components/site/ClientsInfographic";
+
+export default function Clients() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <Section>
+        <ClientsInfographic />
+      </Section>
+    </div>
+  );
+}

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -1,5 +1,6 @@
 import Section from "@/components/site/Section";
 import TiltCard from "@/components/site/TiltCard";
+import ClientsInfographic from "@/components/site/ClientsInfographic";
 import { Cpu, Palette, Target, BarChart3, Cloud, Zap, Shield } from "lucide-react";
 import { useEffect, useState } from "react";
 

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -47,8 +47,6 @@ export default function Services() {
         </ul>
       </Section>
 
-      <ClientsInfographic />
-
       <Section className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" delay={0.1}>
         {(() => {
           const wanted = [

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -5,34 +5,10 @@ import { Cpu, Palette, Target, BarChart3 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export default function Services() {
-  const [items, setItems] = useState<any[]>([]);
-  const [projectCards, setProjectCards] = useState<any[] | null>(null);
+  const [flowItems, setFlowItems] = useState<any[] | null>(null);
 
   useEffect(() => {
-    (async () => {
-      try {
-        const s = await fetch("/api/services").then((r) => r.json());
-        const arr = Array.isArray(s) ? s.filter((x: any) => x.enabled !== false) : [];
-        setItems(
-          arr.length
-            ? arr
-            : [
-                { id: "sv1", title: "Strategy", description: "From discovery to roadmap, aligning on outcomes." },
-                { id: "sv2", title: "Design", description: "Accessible, modern interfaces with purpose." },
-              ],
-        );
-      } catch (e) {
-        console.error(e);
-        setItems([
-          { id: "sv1", title: "Strategy", description: "From discovery to roadmap, aligning on outcomes." },
-          { id: "sv2", title: "Design", description: "Accessible, modern interfaces with purpose." },
-        ]);
-      }
-    })();
-  }, []);
-
-  useEffect(() => {
-    // load section with key 'flowchart' and use its data items for project cards
+    // load section with key 'flowchart' and use its data items for service tiles
     (async () => {
       try {
         const sections = await fetch("/api/sections").then((r) => r.json());
@@ -55,10 +31,10 @@ export default function Services() {
           }
         }
         if (arr.length === 0) {
-          setProjectCards(null);
+          setFlowItems(null);
         } else {
           const normalized = arr.map((it: any, idx: number) => {
-            const title = it.title || it.heading || it.label || `Case Study ${idx + 1}`;
+            const title = it.title || it.heading || it.label || `Item ${idx + 1}`;
             const description = it.description || it.subtitle || it.desc || "";
             const image =
               it.image && typeof it.image === "string"
@@ -66,13 +42,13 @@ export default function Services() {
                 : it.image && typeof it.image === "object" && it.image.id
                 ? `/api/assets/${it.image.id}`
                 : it.imageUrl || null;
-            return { title, description, image };
+            return { id: it.id ?? idx, title, description, image, icon: it.icon };
           });
-          setProjectCards(normalized);
+          setFlowItems(normalized);
         }
       } catch (e) {
         console.error("Failed loading flowchart section", e);
-        setProjectCards(null);
+        setFlowItems(null);
       }
     })();
   }, []);

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -23,14 +23,6 @@ export default function Services() {
   return (
     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
       <Section>
-        <AnimatedTitle
-          text="Services"
-          className="text-4xl sm:text-5xl font-extrabold text-foreground"
-        />
-        <p className="mt-4 max-w-prose text-foreground/85">Pragmatic services that ship outcomes—not vanity.</p>
-      </Section>
-
-      <Section>
         <h1 className="text-4xl sm:text-5xl font-extrabold text-foreground">Services</h1>
         <p className="mt-4 max-w-prose text-foreground/85">
           We provide specialized IT services that enhance performance, ensure scalability, and accelerate digital maturity:
@@ -44,18 +36,52 @@ export default function Services() {
       </Section>
 
       <Section className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" delay={0.1}>
-        {(services && services.length ? services : []).map((c, i) => {
-          const Icon = [Target, Palette, Cpu, BarChart3][i % 4] || Target;
-          return (
-            <TiltCard key={c.id || i} className="h-full">
-              <div className="h-6 w-6 text-primary/100">
-                {Icon && <Icon />}
-              </div>
-              <div className="mt-4 font-semibold text-foreground">{c.title}</div>
-              <p className="mt-2 text-sm text-foreground/90">{c.description}</p>
-            </TiltCard>
-          );
-        })}
+        {(() => {
+          const wanted = [
+            'Enterprise Architecture Services',
+            'Cloud Enablement',
+            'AI Augmentation',
+            'Cybersecurity & Vulnerability Assessments',
+          ];
+          const filtered = Array.isArray(services)
+            ? services.filter((s) => wanted.includes(s.title))
+            : [];
+          const fallback = [
+            { id: 'svc1', title: 'Enterprise Architecture Services', description: 'Align technology with business objectives for scale, security, and agility.', icon: 'cpu' },
+            { id: 'svc2', title: 'Cloud Enablement', description: 'Drive cloud adoption, optimization, and resilience.', icon: 'cloud' },
+            { id: 'svc3', title: 'AI Augmentation', description: 'Integrate intelligence into decision-making and operations.', icon: 'zap' },
+            { id: 'svc4', title: 'Cybersecurity & Vulnerability Assessments', description: 'Protect your enterprise with proactive risk management.', icon: 'shield' },
+          ];
+          const toRender = filtered.length ? filtered : fallback;
+          return toRender.map((c, i) => {
+            // Try to map icon name to lucide icon
+            const getIcon = (name: string | undefined) => {
+              if (!name) return [Target, Palette, Cpu, BarChart3][i % 4];
+              const map: Record<string, any> = {
+                target: Target,
+                palette: Palette,
+                cpu: Cpu,
+                'bar-chart-3': BarChart3,
+                cloud: CloudIcon,
+                zap: BarChart3, // fallback mapping
+                shield: BarChart3,
+              };
+              return map[name] || map[name?.toLowerCase?.()] || [Target, Palette, Cpu, BarChart3][i % 4];
+            };
+
+            const Icon = getIcon(c.icon);
+
+            return (
+              <TiltCard key={c.id || i} className="h-full">
+                <div className="h-6 w-6 text-primary/100">
+                  {Icon && <Icon />}
+                </div>
+                <div className="mt-4 font-semibold text-foreground">{c.title}</div>
+                <p className="mt-2 text-sm text-foreground/90">{c.description}</p>
+              </TiltCard>
+            );
+          });
+        })()}
       </Section>
     </div>
   );

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -1,6 +1,14 @@
 import Section from "@/components/site/Section";
 import TiltCard from "@/components/site/TiltCard";
-import { Cpu, Palette, Target, BarChart3, Cloud, Zap, Shield } from "lucide-react";
+import {
+  Cpu,
+  Palette,
+  Target,
+  BarChart3,
+  Cloud,
+  Zap,
+  Shield,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 
 export default function Services() {
@@ -9,11 +17,13 @@ export default function Services() {
   useEffect(() => {
     (async () => {
       try {
-        const s = await fetch('/api/services').then((r) => r.json());
-        const arr = Array.isArray(s) ? s.filter((x: any) => x.enabled !== false) : [];
+        const s = await fetch("/api/services").then((r) => r.json());
+        const arr = Array.isArray(s)
+          ? s.filter((x: any) => x.enabled !== false)
+          : [];
         setServices(arr);
       } catch (e) {
-        console.error('Failed to load services', e);
+        console.error("Failed to load services", e);
         setServices(null);
       }
     })();
@@ -22,9 +32,12 @@ export default function Services() {
   return (
     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
       <Section>
-        <h1 className="text-4xl sm:text-5xl font-extrabold text-foreground">Services</h1>
+        <h1 className="text-4xl sm:text-5xl font-extrabold text-foreground">
+          Services
+        </h1>
         <p className="mt-4 max-w-prose text-foreground/85">
-          We provide specialized IT services that enhance performance, ensure scalability, and accelerate digital maturity:
+          We provide specialized IT services that enhance performance, ensure
+          scalability, and accelerate digital maturity:
         </p>
         <ul className="mt-4 max-w-prose text-foreground/85 list-disc pl-6 space-y-2">
           {(() => {
@@ -32,10 +45,26 @@ export default function Services() {
               ? services.filter((s) => s.enabled !== false)
               : [];
             const fallback = [
-              { title: 'Enterprise Architecture Services', description: 'Align technology with business objectives for scale, security, and agility.' },
-              { title: 'Cloud Enablement', description: 'Drive cloud adoption, optimization, and resilience.' },
-              { title: 'AI Augmentation', description: 'Integrate intelligence into decision-making and operations.' },
-              { title: 'Cybersecurity & Vulnerability Assessments', description: 'Protect your enterprise with proactive risk management.' },
+              {
+                title: "Enterprise Architecture Services",
+                description:
+                  "Align technology with business objectives for scale, security, and agility.",
+              },
+              {
+                title: "Cloud Enablement",
+                description:
+                  "Drive cloud adoption, optimization, and resilience.",
+              },
+              {
+                title: "AI Augmentation",
+                description:
+                  "Integrate intelligence into decision-making and operations.",
+              },
+              {
+                title: "Cybersecurity & Vulnerability Assessments",
+                description:
+                  "Protect your enterprise with proactive risk management.",
+              },
             ];
             const toShow = visible.length ? visible : fallback;
             return toShow.map((s: any) => (
@@ -47,22 +76,49 @@ export default function Services() {
         </ul>
       </Section>
 
-      <Section className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" delay={0.1}>
+      <Section
+        className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6"
+        delay={0.1}
+      >
         {(() => {
           const wanted = [
-            'Enterprise Architecture Services',
-            'Cloud Enablement',
-            'AI Augmentation',
-            'Cybersecurity & Vulnerability Assessments',
+            "Enterprise Architecture Services",
+            "Cloud Enablement",
+            "AI Augmentation",
+            "Cybersecurity & Vulnerability Assessments",
           ];
           const filtered = Array.isArray(services)
             ? services.filter((s) => wanted.includes(s.title))
             : [];
           const fallback = [
-            { id: 'svc1', title: 'Enterprise Architecture Services', description: 'Align technology with business objectives for scale, security, and agility.', icon: 'cpu' },
-            { id: 'svc2', title: 'Cloud Enablement', description: 'Drive cloud adoption, optimization, and resilience.', icon: 'cloud' },
-            { id: 'svc3', title: 'AI Augmentation', description: 'Integrate intelligence into decision-making and operations.', icon: 'zap' },
-            { id: 'svc4', title: 'Cybersecurity & Vulnerability Assessments', description: 'Protect your enterprise with proactive risk management.', icon: 'shield' },
+            {
+              id: "svc1",
+              title: "Enterprise Architecture Services",
+              description:
+                "Align technology with business objectives for scale, security, and agility.",
+              icon: "cpu",
+            },
+            {
+              id: "svc2",
+              title: "Cloud Enablement",
+              description:
+                "Drive cloud adoption, optimization, and resilience.",
+              icon: "cloud",
+            },
+            {
+              id: "svc3",
+              title: "AI Augmentation",
+              description:
+                "Integrate intelligence into decision-making and operations.",
+              icon: "zap",
+            },
+            {
+              id: "svc4",
+              title: "Cybersecurity & Vulnerability Assessments",
+              description:
+                "Protect your enterprise with proactive risk management.",
+              icon: "shield",
+            },
           ];
           const toRender = filtered.length ? filtered : fallback;
           return toRender.map((c, i) => {
@@ -73,12 +129,16 @@ export default function Services() {
                 target: Target,
                 palette: Palette,
                 cpu: Cpu,
-                'bar-chart-3': BarChart3,
+                "bar-chart-3": BarChart3,
                 cloud: Cloud,
                 zap: Zap,
                 shield: Shield,
               };
-              return map[name] || map[name?.toLowerCase?.()] || [Target, Palette, Cpu, BarChart3][i % 4];
+              return (
+                map[name] ||
+                map[name?.toLowerCase?.()] ||
+                [Target, Palette, Cpu, BarChart3][i % 4]
+              );
             };
 
             const Icon = getIcon(c.icon);
@@ -88,8 +148,12 @@ export default function Services() {
                 <div className="h-6 w-6 text-primary/100">
                   {Icon && <Icon />}
                 </div>
-                <div className="mt-4 font-semibold text-foreground">{c.title}</div>
-                <p className="mt-2 text-sm text-foreground/90">{c.description}</p>
+                <div className="mt-4 font-semibold text-foreground">
+                  {c.title}
+                </div>
+                <p className="mt-2 text-sm text-foreground/90">
+                  {c.description}
+                </p>
               </TiltCard>
             );
           });

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -1,7 +1,6 @@
 import Section from "@/components/site/Section";
-import AnimatedTitle from "@/components/site/AnimatedTitle";
 import TiltCard from "@/components/site/TiltCard";
-import { Cpu, Palette, Target, BarChart3 } from "lucide-react";
+import { Cpu, Palette, Target, BarChart3, Cloud, Zap, Shield } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export default function Services() {

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import Section from "@/components/site/Section";
 import AnimatedTitle from "@/components/site/AnimatedTitle";
 import TiltCard from "@/components/site/TiltCard";

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -30,13 +30,26 @@ export default function Services() {
         <p className="mt-4 max-w-prose text-foreground/85">Pragmatic services that ship outcomes—not vanity.</p>
       </Section>
 
+      <Section>
+        <h1 className="text-4xl sm:text-5xl font-extrabold text-foreground">Services</h1>
+        <p className="mt-4 max-w-prose text-foreground/85">
+          We provide specialized IT services that enhance performance, ensure scalability, and accelerate digital maturity:
+        </p>
+        <ul className="mt-4 max-w-prose text-foreground/85 list-disc pl-6 space-y-2">
+          <li>Enterprise Architecture Services – Align technology with business objectives for scale, security, and agility.</li>
+          <li>Cloud Enablement – Drive cloud adoption, optimization, and resilience.</li>
+          <li>AI Augmentation – Integrate intelligence into decision-making and operations.</li>
+          <li>Cybersecurity &amp; Vulnerability Assessments – Protect your enterprise with proactive risk management.</li>
+        </ul>
+      </Section>
+
       <Section className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" delay={0.1}>
-        {(flowItems || []).map((c, i) => {
+        {(services && services.length ? services : []).map((c, i) => {
           const Icon = [Target, Palette, Cpu, BarChart3][i % 4] || Target;
           return (
             <TiltCard key={c.id || i} className="h-full">
               <div className="h-6 w-6 text-primary/100">
-                <Icon />
+                {Icon && <Icon />}
               </div>
               <div className="mt-4 font-semibold text-foreground">{c.title}</div>
               <p className="mt-2 text-sm text-foreground/90">{c.description}</p>

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -27,10 +27,23 @@ export default function Services() {
           We provide specialized IT services that enhance performance, ensure scalability, and accelerate digital maturity:
         </p>
         <ul className="mt-4 max-w-prose text-foreground/85 list-disc pl-6 space-y-2">
-          <li>Enterprise Architecture Services – Align technology with business objectives for scale, security, and agility.</li>
-          <li>Cloud Enablement – Drive cloud adoption, optimization, and resilience.</li>
-          <li>AI Augmentation – Integrate intelligence into decision-making and operations.</li>
-          <li>Cybersecurity &amp; Vulnerability Assessments – Protect your enterprise with proactive risk management.</li>
+          {(() => {
+            const visible = Array.isArray(services)
+              ? services.filter((s) => s.enabled !== false)
+              : [];
+            const fallback = [
+              { title: 'Enterprise Architecture Services', description: 'Align technology with business objectives for scale, security, and agility.' },
+              { title: 'Cloud Enablement', description: 'Drive cloud adoption, optimization, and resilience.' },
+              { title: 'AI Augmentation', description: 'Integrate intelligence into decision-making and operations.' },
+              { title: 'Cybersecurity & Vulnerability Assessments', description: 'Protect your enterprise with proactive risk management.' },
+            ];
+            const toShow = visible.length ? visible : fallback;
+            return toShow.map((s: any) => (
+              <li key={s.id || s.title}>
+                <strong>{s.title}</strong> – {s.description}
+              </li>
+            ));
+          })()}
         </ul>
       </Section>
 

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -5,50 +5,17 @@ import { Cpu, Palette, Target, BarChart3 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export default function Services() {
-  const [flowItems, setFlowItems] = useState<any[] | null>(null);
+  const [services, setServices] = useState<any[] | null>(null);
 
   useEffect(() => {
-    // load section with key 'flowchart' and use its data items for service tiles
     (async () => {
       try {
-        const sections = await fetch("/api/sections").then((r) => r.json());
-        const found = Array.isArray(sections)
-          ? sections.find((x: any) => x.key === "flowchart")
-          : null;
-        const raw = found?.data != null ? found.data : found?.content;
-        let arr: any[] = [];
-        if (raw) {
-          if (Array.isArray(raw)) arr = raw;
-          else if (Array.isArray((raw as any).items)) arr = (raw as any).items;
-          else if (typeof raw === "string") {
-            try {
-              const parsed = JSON.parse(raw);
-              if (Array.isArray(parsed)) arr = parsed;
-              else if (Array.isArray(parsed.items)) arr = parsed.items;
-            } catch (e) {
-              // ignore
-            }
-          }
-        }
-        if (arr.length === 0) {
-          setFlowItems(null);
-        } else {
-          const normalized = arr.map((it: any, idx: number) => {
-            const title = it.title || it.heading || it.label || `Item ${idx + 1}`;
-            const description = it.description || it.subtitle || it.desc || "";
-            const image =
-              it.image && typeof it.image === "string"
-                ? it.image
-                : it.image && typeof it.image === "object" && it.image.id
-                ? `/api/assets/${it.image.id}`
-                : it.imageUrl || null;
-            return { id: it.id ?? idx, title, description, image, icon: it.icon };
-          });
-          setFlowItems(normalized);
-        }
+        const s = await fetch('/api/services').then((r) => r.json());
+        const arr = Array.isArray(s) ? s.filter((x: any) => x.enabled !== false) : [];
+        setServices(arr);
       } catch (e) {
-        console.error("Failed loading flowchart section", e);
-        setFlowItems(null);
+        console.error('Failed to load services', e);
+        setServices(null);
       }
     })();
   }, []);

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -1,6 +1,5 @@
 import Section from "@/components/site/Section";
 import TiltCard from "@/components/site/TiltCard";
-import ClientsInfographic from "@/components/site/ClientsInfographic";
 import { Cpu, Palette, Target, BarChart3, Cloud, Zap, Shield } from "lucide-react";
 import { useEffect, useState } from "react";
 

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -1,51 +1,83 @@
 import { useEffect, useState } from "react";
 import Section from "@/components/site/Section";
 import AnimatedTitle from "@/components/site/AnimatedTitle";
+import TiltCard from "@/components/site/TiltCard";
 import { Cpu, Palette, Target, BarChart3 } from "lucide-react";
+import { useEffect, useState } from "react";
 
 export default function Services() {
   const [items, setItems] = useState<any[]>([]);
+  const [projectCards, setProjectCards] = useState<any[] | null>(null);
+
   useEffect(() => {
     (async () => {
       try {
         const s = await fetch("/api/services").then((r) => r.json());
-        const arr = Array.isArray(s)
-          ? s.filter((x: any) => x.enabled !== false)
-          : [];
+        const arr = Array.isArray(s) ? s.filter((x: any) => x.enabled !== false) : [];
         setItems(
           arr.length
             ? arr
             : [
-                {
-                  id: "sv1",
-                  title: "Strategy",
-                  description:
-                    "From discovery to roadmap, aligning on outcomes.",
-                },
-                {
-                  id: "sv2",
-                  title: "Design",
-                  description: "Accessible, modern interfaces with purpose.",
-                },
+                { id: "sv1", title: "Strategy", description: "From discovery to roadmap, aligning on outcomes." },
+                { id: "sv2", title: "Design", description: "Accessible, modern interfaces with purpose." },
               ],
         );
       } catch (e) {
         console.error(e);
         setItems([
-          {
-            id: "sv1",
-            title: "Strategy",
-            description: "From discovery to roadmap, aligning on outcomes.",
-          },
-          {
-            id: "sv2",
-            title: "Design",
-            description: "Accessible, modern interfaces with purpose.",
-          },
+          { id: "sv1", title: "Strategy", description: "From discovery to roadmap, aligning on outcomes." },
+          { id: "sv2", title: "Design", description: "Accessible, modern interfaces with purpose." },
         ]);
       }
     })();
   }, []);
+
+  useEffect(() => {
+    // load section with key 'flowchart' and use its data items for project cards
+    (async () => {
+      try {
+        const sections = await fetch("/api/sections").then((r) => r.json());
+        const found = Array.isArray(sections)
+          ? sections.find((x: any) => x.key === "flowchart")
+          : null;
+        const raw = found?.data != null ? found.data : found?.content;
+        let arr: any[] = [];
+        if (raw) {
+          if (Array.isArray(raw)) arr = raw;
+          else if (Array.isArray((raw as any).items)) arr = (raw as any).items;
+          else if (typeof raw === "string") {
+            try {
+              const parsed = JSON.parse(raw);
+              if (Array.isArray(parsed)) arr = parsed;
+              else if (Array.isArray(parsed.items)) arr = parsed.items;
+            } catch (e) {
+              // ignore
+            }
+          }
+        }
+        if (arr.length === 0) {
+          setProjectCards(null);
+        } else {
+          const normalized = arr.map((it: any, idx: number) => {
+            const title = it.title || it.heading || it.label || `Case Study ${idx + 1}`;
+            const description = it.description || it.subtitle || it.desc || "";
+            const image =
+              it.image && typeof it.image === "string"
+                ? it.image
+                : it.image && typeof it.image === "object" && it.image.id
+                ? `/api/assets/${it.image.id}`
+                : it.imageUrl || null;
+            return { title, description, image };
+          });
+          setProjectCards(normalized);
+        }
+      } catch (e) {
+        console.error("Failed loading flowchart section", e);
+        setProjectCards(null);
+      }
+    })();
+  }, []);
+
   return (
     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
       <Section>
@@ -53,19 +85,12 @@ export default function Services() {
           text="Services"
           className="text-4xl sm:text-5xl font-extrabold text-foreground"
         />
-        <p className="mt-4 max-w-prose text-foreground/85">
-          Pragmatic services that ship outcomes—not vanity.
-        </p>
+        <p className="mt-4 max-w-prose text-foreground/85">Pragmatic services that ship outcomes—not vanity.</p>
       </Section>
-      <Section
-        className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6"
-        delay={0.1}
-      >
+
+      <Section className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" delay={0.1}>
         {items.map((c, i) => (
-          <div
-            key={i}
-            className="rounded-2xl border border-primary/20 bg-transparent p-6 glass-card"
-          >
+          <div key={i} className="rounded-2xl border border-primary/20 bg-transparent p-6 glass-card">
             <div className="h-6 w-6 text-primary/100">
               <Target />
             </div>
@@ -74,28 +99,24 @@ export default function Services() {
           </div>
         ))}
       </Section>
+
       <Section className="mt-16" delay={0.15}>
         <h2 className="text-2xl font-bold text-foreground">Project Details</h2>
         <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-6">
-          {[1, 2, 3].map((n) => (
-            <div
-              key={n}
-              className="rounded-2xl border border-primary/20 bg-black/10 overflow-hidden"
-            >
-              <img
-                src="/placeholder.svg"
-                alt=""
-                className="h-40 w-full object-cover border-b border-primary/20"
-              />
-              <div className="p-6">
-                <div className="font-semibold text-foreground">
-                  Case Study {n}
-                </div>
-                <p className="mt-2 text-sm text-foreground/80">
-                  Outcome‑focused delivery with crisp constraints.
-                </p>
+          {(projectCards || [
+            { title: "Case Study 1", description: "Outcome‑focused delivery with crisp constraints.", image: "/placeholder.svg" },
+            { title: "Case Study 2", description: "Outcome‑focused delivery with crisp constraints.", image: "/placeholder.svg" },
+            { title: "Case Study 3", description: "Outcome‑focused delivery with crisp constraints.", image: "/placeholder.svg" },
+          ]).map((card, idx) => (
+            <TiltCard key={idx} className="h-full">
+              <div className="overflow-hidden rounded-2xl">
+                <img src={card.image || "/placeholder.svg"} alt="" className="h-40 w-full object-cover border-b border-primary/20" />
               </div>
-            </div>
+              <div className="p-6">
+                <div className="font-semibold text-foreground">{card.title}</div>
+                <p className="mt-2 text-sm text-foreground/80">{card.description}</p>
+              </div>
+            </TiltCard>
           ))}
         </div>
       </Section>

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -88,15 +88,18 @@ export default function Services() {
       </Section>
 
       <Section className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" delay={0.1}>
-        {items.map((c, i) => (
-          <div key={i} className="rounded-2xl border border-primary/20 bg-transparent p-6 glass-card">
-            <div className="h-6 w-6 text-primary/100">
-              <Target />
-            </div>
-            <div className="mt-4 font-semibold text-foreground">{c.title}</div>
-            <p className="mt-2 text-sm text-foreground/90">{c.description}</p>
-          </div>
-        ))}
+        {items.map((c, i) => {
+          const Icon = [Target, Palette, Cpu, BarChart3][i % 4] || Target;
+          return (
+            <TiltCard key={c.id || i} className="h-full">
+              <div className="h-6 w-6 text-primary/100">
+                <Icon />
+              </div>
+              <div className="mt-4 font-semibold text-foreground">{c.title}</div>
+              <p className="mt-2 text-sm text-foreground/90">{c.description}</p>
+            </TiltCard>
+          );
+        })}
       </Section>
 
       <Section className="mt-16" delay={0.15}>

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -64,7 +64,7 @@ export default function Services() {
       </Section>
 
       <Section className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" delay={0.1}>
-        {items.map((c, i) => {
+        {(flowItems || []).map((c, i) => {
           const Icon = [Target, Palette, Cpu, BarChart3][i % 4] || Target;
           return (
             <TiltCard key={c.id || i} className="h-full">
@@ -76,27 +76,6 @@ export default function Services() {
             </TiltCard>
           );
         })}
-      </Section>
-
-      <Section className="mt-16" delay={0.15}>
-        <h2 className="text-2xl font-bold text-foreground">Project Details</h2>
-        <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-6">
-          {(projectCards || [
-            { title: "Case Study 1", description: "Outcome‑focused delivery with crisp constraints.", image: "/placeholder.svg" },
-            { title: "Case Study 2", description: "Outcome‑focused delivery with crisp constraints.", image: "/placeholder.svg" },
-            { title: "Case Study 3", description: "Outcome‑focused delivery with crisp constraints.", image: "/placeholder.svg" },
-          ]).map((card, idx) => (
-            <TiltCard key={idx} className="h-full">
-              <div className="overflow-hidden rounded-2xl">
-                <img src={card.image || "/placeholder.svg"} alt="" className="h-40 w-full object-cover border-b border-primary/20" />
-              </div>
-              <div className="p-6">
-                <div className="font-semibold text-foreground">{card.title}</div>
-                <p className="mt-2 text-sm text-foreground/80">{card.description}</p>
-              </div>
-            </TiltCard>
-          ))}
-        </div>
       </Section>
     </div>
   );

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -48,6 +48,8 @@ export default function Services() {
         </ul>
       </Section>
 
+      <ClientsInfographic />
+
       <Section className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" delay={0.1}>
         {(() => {
           const wanted = [

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -61,9 +61,9 @@ export default function Services() {
                 palette: Palette,
                 cpu: Cpu,
                 'bar-chart-3': BarChart3,
-                cloud: CloudIcon,
-                zap: BarChart3, // fallback mapping
-                shield: BarChart3,
+                cloud: Cloud,
+                zap: Zap,
+                shield: Shield,
               };
               return map[name] || map[name?.toLowerCase?.()] || [Target, Palette, Cpu, BarChart3][i % 4];
             };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,6 +83,18 @@ model Testimonial {
   enabled  Boolean @default(true)
 }
 
+model ClientSection {
+  id          String  @id @default(cuid())
+  heading     String
+  subheading  String?
+  details     Json?
+  imageUrl    String?
+  imageId     String?
+  image       Asset?  @relation("ClientSectionImage", fields: [imageId], references: [id])
+  order       Int?    @default(0)
+  enabled     Boolean @default(true)
+}
+
 model Job {
   id          String @id @default(cuid())
   title       String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,10 @@ model About {
   valuesHeading    String?
   valuesSubheading String?
   valuesCards      Json?
+  // How We Serve timeline
+  serveHeading     String?
+  serveSubheading  String?
+  serveSteps       Json?
   enabled          Boolean @default(true)
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -130,4 +130,5 @@ model Asset {
   testimonials Testimonial[] @relation("TestimonialAvatar")
   sections     Section[]     @relation("SectionImage")
   services     Service[]     @relation("ServiceImage")
+  clientSections ClientSection[] @relation("ClientSectionImage")
 }

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -63,13 +63,27 @@ router.get("/testimonials", async (_req, res) => {
 
 router.get("/services", async (_req, res) => {
   try {
-    const items = await prisma.service.findMany({ orderBy: { order: 'asc' } as any });
+    const items = await prisma.service.findMany({
+      orderBy: { order: "asc" } as any,
+    });
     if (!items || items.length === 0)
-      return res.json(Array.isArray(memoryDb.services) ? [...memoryDb.services].sort((a: any, b: any) => (a.order || 0) - (b.order || 0)) : memoryDb.services);
+      return res.json(
+        Array.isArray(memoryDb.services)
+          ? [...memoryDb.services].sort(
+              (a: any, b: any) => (a.order || 0) - (b.order || 0),
+            )
+          : memoryDb.services,
+      );
     res.json(items);
   } catch (e) {
     console.warn("Prisma services failed, using memory store", e.message || e);
-    res.json(Array.isArray(memoryDb.services) ? [...memoryDb.services].sort((a: any, b: any) => (a.order || 0) - (b.order || 0)) : memoryDb.services);
+    res.json(
+      Array.isArray(memoryDb.services)
+        ? [...memoryDb.services].sort(
+            (a: any, b: any) => (a.order || 0) - (b.order || 0),
+          )
+        : memoryDb.services,
+    );
   }
 });
 
@@ -87,13 +101,21 @@ router.get("/projects", async (_req, res) => {
 });
 
 router.get("/clients", async (_req, res) => {
-  res.setHeader("Cache-Control", "public, max-age=60, stale-while-revalidate=120");
+  res.setHeader(
+    "Cache-Control",
+    "public, max-age=60, stale-while-revalidate=120",
+  );
   try {
-    const items = await prisma.clientSection.findMany({ orderBy: { order: 'asc' } as any, include: { image: true } as any });
+    const items = await prisma.clientSection.findMany({
+      orderBy: { order: "asc" } as any,
+      include: { image: true } as any,
+    });
     if (!items || items.length === 0) return res.json(memoryDb.clients || []);
     const normalized = items.map((item: any) => {
-      const assetUrl = item?.image && item.image?.id ? `/api/assets/${item.image.id}` : null;
-      const explicitUrl = typeof item?.imageUrl === 'string' ? item.imageUrl.trim() : null;
+      const assetUrl =
+        item?.image && item.image?.id ? `/api/assets/${item.image.id}` : null;
+      const explicitUrl =
+        typeof item?.imageUrl === "string" ? item.imageUrl.trim() : null;
       const image = explicitUrl && explicitUrl.length ? explicitUrl : assetUrl;
       return {
         id: item.id,

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -117,6 +117,10 @@ router.get("/about", async (_req, res) => {
         valuesHeading: (item as any).valuesHeading || null,
         valuesSubheading: (item as any).valuesSubheading || null,
         valuesCards: (item as any).valuesCards || null,
+        // How We Serve timeline
+        serveHeading: (item as any).serveHeading || null,
+        serveSubheading: (item as any).serveSubheading || null,
+        serveSteps: (item as any).serveSteps || null,
       };
     });
 

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -63,12 +63,13 @@ router.get("/testimonials", async (_req, res) => {
 
 router.get("/services", async (_req, res) => {
   try {
-    const items = await prisma.service.findMany();
-    if (!items || items.length === 0) return res.json(memoryDb.services);
+    const items = await prisma.service.findMany({ orderBy: { order: 'asc' } as any });
+    if (!items || items.length === 0)
+      return res.json(Array.isArray(memoryDb.services) ? [...memoryDb.services].sort((a: any, b: any) => (a.order || 0) - (b.order || 0)) : memoryDb.services);
     res.json(items);
   } catch (e) {
     console.warn("Prisma services failed, using memory store", e.message || e);
-    res.json(memoryDb.services);
+    res.json(Array.isArray(memoryDb.services) ? [...memoryDb.services].sort((a: any, b: any) => (a.order || 0) - (b.order || 0)) : memoryDb.services);
   }
 });
 

--- a/server/scripts/ensureClients.ts
+++ b/server/scripts/ensureClients.ts
@@ -1,15 +1,23 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
 const payload = {
-  heading: 'Clients & Reach',
-  subheading: 'Trusted by forward-looking organizations across industries:',
+  heading: "Clients & Reach",
+  subheading: "Trusted by forward-looking organizations across industries:",
   details: [
-    { industry: 'Retail', count: '35+', region: 'India' },
-    { industry: 'Financial Services (NBFCs)', count: '5', region: 'India & Dubai' },
-    { industry: 'Engineering (MEP)', count: '2', region: 'Dubai, Abu Dhabi & Qatar' },
-    { industry: 'Data & Infrastructure', count: '5', region: 'Middle East' },
+    { industry: "Retail", count: "35+", region: "India" },
+    {
+      industry: "Financial Services (NBFCs)",
+      count: "5",
+      region: "India & Dubai",
+    },
+    {
+      industry: "Engineering (MEP)",
+      count: "2",
+      region: "Dubai, Abu Dhabi & Qatar",
+    },
+    { industry: "Data & Infrastructure", count: "5", region: "Middle East" },
   ],
   enabled: true,
   order: 0,
@@ -17,16 +25,21 @@ const payload = {
 
 async function run() {
   try {
-    const existing = await prisma.clientSection.findFirst({ where: { heading: payload.heading } });
+    const existing = await prisma.clientSection.findFirst({
+      where: { heading: payload.heading },
+    });
     if (existing) {
-      await prisma.clientSection.update({ where: { id: existing.id }, data: payload });
-      console.log('Updated clients section');
+      await prisma.clientSection.update({
+        where: { id: existing.id },
+        data: payload,
+      });
+      console.log("Updated clients section");
     } else {
       await prisma.clientSection.create({ data: payload });
-      console.log('Created clients section');
+      console.log("Created clients section");
     }
   } catch (e) {
-    console.error('Ensure clients failed', e);
+    console.error("Ensure clients failed", e);
     process.exitCode = 1;
   } finally {
     await prisma.$disconnect();

--- a/server/scripts/ensureClients.ts
+++ b/server/scripts/ensureClients.ts
@@ -1,0 +1,36 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const payload = {
+  heading: 'Clients & Reach',
+  subheading: 'Trusted by forward-looking organizations across industries:',
+  details: [
+    { industry: 'Retail', count: '35+', region: 'India' },
+    { industry: 'Financial Services (NBFCs)', count: '5', region: 'India & Dubai' },
+    { industry: 'Engineering (MEP)', count: '2', region: 'Dubai, Abu Dhabi & Qatar' },
+    { industry: 'Data & Infrastructure', count: '5', region: 'Middle East' },
+  ],
+  enabled: true,
+  order: 0,
+};
+
+async function run() {
+  try {
+    const existing = await prisma.clientSection.findFirst({ where: { heading: payload.heading } });
+    if (existing) {
+      await prisma.clientSection.update({ where: { id: existing.id }, data: payload });
+      console.log('Updated clients section');
+    } else {
+      await prisma.clientSection.create({ data: payload });
+      console.log('Created clients section');
+    }
+  } catch (e) {
+    console.error('Ensure clients failed', e);
+    process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+run();

--- a/server/scripts/ensureServices.ts
+++ b/server/scripts/ensureServices.ts
@@ -1,0 +1,54 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const services = [
+  {
+    title: 'Enterprise Architecture Services',
+    description: 'Align technology with business objectives for scale, security, and agility.',
+    icon: 'cpu',
+  },
+  {
+    title: 'Cloud Enablement',
+    description: 'Drive cloud adoption, optimization, and resilience.',
+    icon: 'cloud',
+  },
+  {
+    title: 'AI Augmentation',
+    description: 'Integrate intelligence into decision-making and operations.',
+    icon: 'zap',
+  },
+  {
+    title: 'Cybersecurity & Vulnerability Assessments',
+    description: 'Protect your enterprise with proactive risk management.',
+    icon: 'shield',
+  },
+];
+
+async function run() {
+  try {
+    for (const s of services) {
+      const existing = await prisma.service.findFirst({ where: { title: s.title } });
+      if (existing) {
+        console.log(`Service exists: ${s.title}`);
+        // update description/icon if missing
+        await prisma.service.update({
+          where: { id: existing.id },
+          data: { description: s.description, icon: s.icon },
+        });
+      } else {
+        await prisma.service.create({ data: s });
+        console.log(`Created service: ${s.title}`);
+      }
+    }
+    const count = await prisma.service.count();
+    console.log(`Total services: ${count}`);
+  } catch (e) {
+    console.error('Ensure services failed', e);
+    process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+run();

--- a/server/scripts/ensureServices.ts
+++ b/server/scripts/ensureServices.ts
@@ -1,34 +1,37 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
 const services = [
   {
-    title: 'Enterprise Architecture Services',
-    description: 'Align technology with business objectives for scale, security, and agility.',
-    icon: 'cpu',
+    title: "Enterprise Architecture Services",
+    description:
+      "Align technology with business objectives for scale, security, and agility.",
+    icon: "cpu",
   },
   {
-    title: 'Cloud Enablement',
-    description: 'Drive cloud adoption, optimization, and resilience.',
-    icon: 'cloud',
+    title: "Cloud Enablement",
+    description: "Drive cloud adoption, optimization, and resilience.",
+    icon: "cloud",
   },
   {
-    title: 'AI Augmentation',
-    description: 'Integrate intelligence into decision-making and operations.',
-    icon: 'zap',
+    title: "AI Augmentation",
+    description: "Integrate intelligence into decision-making and operations.",
+    icon: "zap",
   },
   {
-    title: 'Cybersecurity & Vulnerability Assessments',
-    description: 'Protect your enterprise with proactive risk management.',
-    icon: 'shield',
+    title: "Cybersecurity & Vulnerability Assessments",
+    description: "Protect your enterprise with proactive risk management.",
+    icon: "shield",
   },
 ];
 
 async function run() {
   try {
     for (const s of services) {
-      const existing = await prisma.service.findFirst({ where: { title: s.title } });
+      const existing = await prisma.service.findFirst({
+        where: { title: s.title },
+      });
       if (existing) {
         console.log(`Service exists: ${s.title}`);
         // update description/icon if missing
@@ -44,7 +47,7 @@ async function run() {
     const count = await prisma.service.count();
     console.log(`Total services: ${count}`);
   } catch (e) {
-    console.error('Ensure services failed', e);
+    console.error("Ensure services failed", e);
     process.exitCode = 1;
   } finally {
     await prisma.$disconnect();

--- a/server/scripts/updateAboutWithServe.ts
+++ b/server/scripts/updateAboutWithServe.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
@@ -6,48 +6,52 @@ async function run() {
   try {
     const items = await prisma.about.findMany();
     if (!items || items.length === 0) {
-      console.log('No about rows found');
+      console.log("No about rows found");
       return;
     }
 
     for (const item of items) {
-      const needServe = (item as any).serveSteps == null ||
-        ((item as any).serveSteps && Array.isArray((item as any).serveSteps) && (item as any).serveSteps.length === 0);
+      const needServe =
+        (item as any).serveSteps == null ||
+        ((item as any).serveSteps &&
+          Array.isArray((item as any).serveSteps) &&
+          (item as any).serveSteps.length === 0);
       if (!needServe) {
         console.log(`About ${item.id} already has serve fields`);
         continue;
       }
 
-      const serveHeading = 'How We Serve';
-      const serveSubheading = 'Our proven methodology that ensures successful project delivery from concept to completion.';
+      const serveHeading = "How We Serve";
+      const serveSubheading =
+        "Our proven methodology that ensures successful project delivery from concept to completion.";
       const serveSteps = [
         {
-          phase: '01',
-          title: 'Discover',
+          phase: "01",
+          title: "Discover",
           description:
-            'Align on goals, constraints, and success metrics. We dive deep into understanding your vision and requirements.',
-          icon: 'target',
+            "Align on goals, constraints, and success metrics. We dive deep into understanding your vision and requirements.",
+          icon: "target",
         },
         {
-          phase: '02',
-          title: 'Design',
+          phase: "02",
+          title: "Design",
           description:
-            'Prototype, test, refine with users and stakeholders. Creating user-centered designs that solve real problems.',
-          icon: 'globe',
+            "Prototype, test, refine with users and stakeholders. Creating user-centered designs that solve real problems.",
+          icon: "globe",
         },
         {
-          phase: '03',
-          title: 'Build',
+          phase: "03",
+          title: "Build",
           description:
-            'Implement iteratively with quality gates and CI. Building robust, scalable solutions with modern technologies.',
-          icon: 'trending-up',
+            "Implement iteratively with quality gates and CI. Building robust, scalable solutions with modern technologies.",
+          icon: "trending-up",
         },
         {
-          phase: '04',
-          title: 'Evolve',
+          phase: "04",
+          title: "Evolve",
           description:
-            'Measure outcomes, learn, and iterate. Continuous improvement based on data and user feedback.',
-          icon: 'zap',
+            "Measure outcomes, learn, and iterate. Continuous improvement based on data and user feedback.",
+          icon: "zap",
         },
       ];
 
@@ -63,7 +67,7 @@ async function run() {
       console.log(`Updated about ${item.id} with serve fields`);
     }
   } catch (e) {
-    console.error('Update failed', e);
+    console.error("Update failed", e);
     process.exitCode = 1;
   } finally {
     await prisma.$disconnect();

--- a/server/scripts/updateAboutWithServe.ts
+++ b/server/scripts/updateAboutWithServe.ts
@@ -1,0 +1,73 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function run() {
+  try {
+    const items = await prisma.about.findMany();
+    if (!items || items.length === 0) {
+      console.log('No about rows found');
+      return;
+    }
+
+    for (const item of items) {
+      const needServe = (item as any).serveSteps == null ||
+        ((item as any).serveSteps && Array.isArray((item as any).serveSteps) && (item as any).serveSteps.length === 0);
+      if (!needServe) {
+        console.log(`About ${item.id} already has serve fields`);
+        continue;
+      }
+
+      const serveHeading = 'How We Serve';
+      const serveSubheading = 'Our proven methodology that ensures successful project delivery from concept to completion.';
+      const serveSteps = [
+        {
+          phase: '01',
+          title: 'Discover',
+          description:
+            'Align on goals, constraints, and success metrics. We dive deep into understanding your vision and requirements.',
+          icon: 'target',
+        },
+        {
+          phase: '02',
+          title: 'Design',
+          description:
+            'Prototype, test, refine with users and stakeholders. Creating user-centered designs that solve real problems.',
+          icon: 'globe',
+        },
+        {
+          phase: '03',
+          title: 'Build',
+          description:
+            'Implement iteratively with quality gates and CI. Building robust, scalable solutions with modern technologies.',
+          icon: 'trending-up',
+        },
+        {
+          phase: '04',
+          title: 'Evolve',
+          description:
+            'Measure outcomes, learn, and iterate. Continuous improvement based on data and user feedback.',
+          icon: 'zap',
+        },
+      ];
+
+      await prisma.about.update({
+        where: { id: item.id },
+        data: {
+          serveHeading,
+          serveSubheading,
+          serveSteps,
+        },
+      });
+
+      console.log(`Updated about ${item.id} with serve fields`);
+    }
+  } catch (e) {
+    console.error('Update failed', e);
+    process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+run();

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -133,20 +133,24 @@ export async function seed() {
       await prisma.service.createMany({
         data: [
           {
-            title: "Strategy",
-            description: "From discovery to roadmap, aligning on outcomes.",
+            title: "Enterprise Architecture Services",
+            description: "Align technology with business objectives for scale, security, and agility.",
+            icon: "cpu",
           },
           {
-            title: "Design",
-            description: "Accessible, modern interfaces with purpose.",
+            title: "Cloud Enablement",
+            description: "Drive cloud adoption, optimization, and resilience.",
+            icon: "cloud",
           },
           {
-            title: "Engineering",
-            description: "Robust web apps, APIs, and infra.",
+            title: "AI Augmentation",
+            description: "Integrate intelligence into decision-making and operations.",
+            icon: "zap",
           },
           {
-            title: "Analytics",
-            description: "Ship, learn, iterate with data.",
+            title: "Cybersecurity & Vulnerability Assessments",
+            description: "Protect your enterprise with proactive risk management.",
+            icon: "shield",
           },
         ],
       });

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -134,7 +134,8 @@ export async function seed() {
         data: [
           {
             title: "Enterprise Architecture Services",
-            description: "Align technology with business objectives for scale, security, and agility.",
+            description:
+              "Align technology with business objectives for scale, security, and agility.",
             icon: "cpu",
           },
           {
@@ -144,12 +145,14 @@ export async function seed() {
           },
           {
             title: "AI Augmentation",
-            description: "Integrate intelligence into decision-making and operations.",
+            description:
+              "Integrate intelligence into decision-making and operations.",
             icon: "zap",
           },
           {
             title: "Cybersecurity & Vulnerability Assessments",
-            description: "Protect your enterprise with proactive risk management.",
+            description:
+              "Protect your enterprise with proactive risk management.",
             icon: "shield",
           },
         ],

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -160,6 +160,40 @@ export async function seed() {
           content:
             "We are a compact team focused on clarity, velocity, and measurable outcomes.",
           imageId: asset.id,
+          // How We Serve timeline
+          serveHeading: "How We Serve",
+          serveSubheading:
+            "Our proven methodology that ensures successful project delivery from concept to completion.",
+          serveSteps: [
+            {
+              phase: "01",
+              title: "Discover",
+              description:
+                "Align on goals, constraints, and success metrics. We dive deep into understanding your vision and requirements.",
+              icon: "target",
+            },
+            {
+              phase: "02",
+              title: "Design",
+              description:
+                "Prototype, test, refine with users and stakeholders. Creating user-centered designs that solve real problems.",
+              icon: "globe",
+            },
+            {
+              phase: "03",
+              title: "Build",
+              description:
+                "Implement iteratively with quality gates and CI. Building robust, scalable solutions with modern technologies.",
+              icon: "trending-up",
+            },
+            {
+              phase: "04",
+              title: "Evolve",
+              description:
+                "Measure outcomes, learn, and iterate. Continuous improvement based on data and user feedback.",
+              icon: "zap",
+            },
+          ],
           awards: [
             {
               icon: "award",

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -295,6 +295,40 @@ export async function seed() {
                 subtitle: "Consistently meeting global benchmarks",
               },
             ],
+            // How We Serve timeline
+            serveHeading: "How We Serve",
+            serveSubheading:
+              "Our proven methodology that ensures successful project delivery from concept to completion.",
+            serveSteps: [
+              {
+                phase: "01",
+                title: "Discover",
+                description:
+                  "Align on goals, constraints, and success metrics. We dive deep into understanding your vision and requirements.",
+                icon: "target",
+              },
+              {
+                phase: "02",
+                title: "Design",
+                description:
+                  "Prototype, test, refine with users and stakeholders. Creating user-centered designs that solve real problems.",
+                icon: "globe",
+              },
+              {
+                phase: "03",
+                title: "Build",
+                description:
+                  "Implement iteratively with quality gates and CI. Building robust, scalable solutions with modern technologies.",
+                icon: "trending-up",
+              },
+              {
+                phase: "04",
+                title: "Evolve",
+                description:
+                  "Measure outcomes, learn, and iterate. Continuous improvement based on data and user feedback.",
+                icon: "zap",
+              },
+            ],
           },
         });
       }

--- a/server/store.ts
+++ b/server/store.ts
@@ -245,6 +245,22 @@ class MemoryDB {
         },
       );
     }
+
+    if (this.clients.length === 0) {
+      this.clients.push({
+        id: uid(),
+        heading: "Clients & Reach",
+        subheading: "Trusted by forward-looking organizations across industries:",
+        details: [
+          { industry: "Retail", count: "35+", region: "India" },
+          { industry: "Financial Services (NBFCs)", count: "5", region: "India & Dubai" },
+          { industry: "Engineering (MEP)", count: "2", region: "Dubai, Abu Dhabi & Qatar" },
+          { industry: "Data & Infrastructure", count: "5", region: "Middle East" },
+        ],
+        enabled: true,
+        order: 0,
+      });
+    }
     if (this.serve.length === 0) {
       this.serve.push(
         {

--- a/server/store.ts
+++ b/server/store.ts
@@ -91,7 +91,15 @@ class MemoryDB {
   jobs: JobItem[] = [];
   serve: ServeStep[] = [];
   sections: SectionItem[] = [];
-  clients: { id: ID; heading: string; subheading?: string; details?: any[]; image?: string; enabled?: boolean; order?: number }[] = [];
+  clients: {
+    id: ID;
+    heading: string;
+    subheading?: string;
+    details?: any[];
+    image?: string;
+    enabled?: boolean;
+    order?: number;
+  }[] = [];
   policies: { id: ID; title: string; content?: string; createdAt?: string }[] =
     [];
   contact: {
@@ -251,12 +259,25 @@ class MemoryDB {
       this.clients.push({
         id: uid(),
         heading: "Clients & Reach",
-        subheading: "Trusted by forward-looking organizations across industries:",
+        subheading:
+          "Trusted by forward-looking organizations across industries:",
         details: [
           { industry: "Retail", count: "35+", region: "India" },
-          { industry: "Financial Services (NBFCs)", count: "5", region: "India & Dubai" },
-          { industry: "Engineering (MEP)", count: "2", region: "Dubai, Abu Dhabi & Qatar" },
-          { industry: "Data & Infrastructure", count: "5", region: "Middle East" },
+          {
+            industry: "Financial Services (NBFCs)",
+            count: "5",
+            region: "India & Dubai",
+          },
+          {
+            industry: "Engineering (MEP)",
+            count: "2",
+            region: "Dubai, Abu Dhabi & Qatar",
+          },
+          {
+            industry: "Data & Infrastructure",
+            count: "5",
+            region: "Middle East",
+          },
         ],
         enabled: true,
         order: 0,

--- a/server/store.ts
+++ b/server/store.ts
@@ -91,6 +91,7 @@ class MemoryDB {
   jobs: JobItem[] = [];
   serve: ServeStep[] = [];
   sections: SectionItem[] = [];
+  clients: { id: ID; heading: string; subheading?: string; details?: any[]; image?: string; enabled?: boolean; order?: number }[] = [];
   policies: { id: ID; title: string; content?: string; createdAt?: string }[] =
     [];
   contact: {

--- a/server/store.ts
+++ b/server/store.ts
@@ -51,6 +51,14 @@ export interface AboutContent {
   heading: string;
   content: string;
   image?: string;
+  awards?: any[];
+  leadership?: any[];
+  valuesHeading?: string;
+  valuesSubheading?: string;
+  valuesCards?: any[];
+  serveHeading?: string;
+  serveSubheading?: string;
+  serveSteps?: any[];
 }
 export interface ServeStep {
   id: ID;
@@ -120,6 +128,40 @@ class MemoryDB {
           "We are a compact team focused on clarity, velocity, and measurable outcomes.",
         image:
           "https://images.unsplash.com/photo-1522075469751-3a6694fb2f61?auto=format&fit=crop&w=1200&q=80",
+        // How We Serve defaults
+        serveHeading: "How We Serve",
+        serveSubheading:
+          "Our proven methodology that ensures successful project delivery from concept to completion.",
+        serveSteps: [
+          {
+            phase: "01",
+            title: "Discover",
+            description:
+              "Align on goals, constraints, and success metrics. We dive deep into understanding your vision and requirements.",
+            icon: "target",
+          },
+          {
+            phase: "02",
+            title: "Design",
+            description:
+              "Prototype, test, refine with users and stakeholders. Creating user-centered designs that solve real problems.",
+            icon: "globe",
+          },
+          {
+            phase: "03",
+            title: "Build",
+            description:
+              "Implement iteratively with quality gates and CI. Building robust, scalable solutions with modern technologies.",
+            icon: "trending-up",
+          },
+          {
+            phase: "04",
+            title: "Evolve",
+            description:
+              "Measure outcomes, learn, and iterate. Continuous improvement based on data and user feedback.",
+            icon: "zap",
+          },
+        ],
         awards: [
           {
             icon: "trophy",


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several key requirements:
- Move client information from Services page to a dedicated Clients page
- Remove "Clients & Reach" section and infographics from Services page
- Add animations to circle tiles on the new Clients page
- Fix runtime errors that were occurring

## Code changes

### Frontend Changes
- **New Clients page**: Created `/client/pages/Clients.tsx` with dedicated route `/clients`
- **Animated infographic component**: Added `ClientsInfographic.tsx` with floating animations for circle tiles using CSS keyframes
- **Services page cleanup**: Removed client-related content and infographics, updated service offerings to focus on core technical services
- **About page enhancements**: Made "How We Serve" section configurable with dynamic content from database

### Backend Changes
- **Database schema updates**: Added new fields to About model for configurable serve steps
- **Seed data improvements**: Updated default services and added client data structure
- **Migration script**: Added script to populate existing About records with serve step data
- **API endpoints**: Enhanced data structure to support the new Clients page content

### Key Features
- Circle tiles with staggered floating animations (varying duration and delay)
- Responsive grid layout for client statistics
- Configurable content management for all sections
- Clean separation of concerns between Services and Clients pages

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/34ddc12454704bdd8143fedca59e12ce/quantum-space)

👀 [Preview Link](https://34ddc12454704bdd8143fedca59e12ce-quantum-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>34ddc12454704bdd8143fedca59e12ce</projectId>-->
<!--<branchName>quantum-space</branchName>-->